### PR TITLE
Allow MomentJS date formats

### DIFF
--- a/addon/components/ember-youtube.js
+++ b/addon/components/ember-youtube.js
@@ -2,6 +2,7 @@
 import Ember from 'ember';
 
 const { computed, debug, observer, on, run } = Ember;
+var moment = window.moment;
 
 export default Ember.Component.extend({
 	classNames: ['EmberYoutube'],
@@ -14,6 +15,8 @@ export default Ember.Component.extend({
 	showProgress: false,
 	showDebug: false,
 	autoplay: 0,
+	currentTimeFormat: "mm:ss",
+	durationFormat: "mm:ss",
 
 	// from YT.PlayerState
 	stateNames: {
@@ -202,14 +205,13 @@ export default Ember.Component.extend({
 		return value ? value : 0;
 	}),
 
-	// returns a 0:00 format
-	currentTimeFormatted: computed('currentTime', function() {
+	// returns a momentJS formated date based on "currentTimeFormat" property
+	currentTimeFormatted: computed('currentTime', 'currentTimeFormat', function() {
 		let time = this.get('currentTime');
-		if (!time) { return; }
-		let minutes = Math.floor(time / 60);
-		let seconds = Math.floor(time - minutes * 60);
-		if (seconds < 10) { seconds = '0' + seconds; }
-		return minutes + ':' + seconds;
+		let format = this.get('currentTimeFormat');
+		if (!time || !format) { return; }
+		let duration = moment.duration(time, 'seconds');		
+		return duration.format(format);
 	}),
 
 	// avoids 'undefined' value for the <progress> element
@@ -218,13 +220,13 @@ export default Ember.Component.extend({
 		return value ? value : 0;
 	}),
 
-	// returns a 0:00 format
-	durationFormatted: computed('duration', function() {
+	// returns a momentJS formated date based on "durationFormat" property
+	durationFormatted: computed('duration', 'durationFormat', function() {
 		let time = this.get('duration');
-		if (!time) { return; }
-		let minutes = Math.floor(time / 60);
-		let seconds = time - minutes * 60;
-		return minutes + ':' + seconds;
+		let format = this.get('durationFormat');
+		if (!time || !format) { return; }
+		let duration = moment.duration(time, 'seconds');		
+		return duration.format(format);
 	}),
 
 	// OK, this is really stupid but couldn't access the "event" inside

--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,8 @@
     "ember-resolver": "~0.1.15",
     "jquery": "^1.11.1",
     "loader.js": "ember-cli/loader.js#3.2.0",
-    "qunit": "~1.17.1"
+    "qunit": "~1.17.1",
+    "moment": "2.10.3",
+    "moment-duration-format": "1.3.0"
   }
 }

--- a/index.js
+++ b/index.js
@@ -2,5 +2,12 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-youtube'
+  name: 'ember-youtube',
+
+  included: function(app) {
+    this._super.included(app);
+
+    app.import(app.bowerDirectory + '/moment/moment.js');
+    app.import(app.bowerDirectory + '/moment-duration-format/lib/moment-duration-format.js');
+  }
 };

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -16,6 +16,7 @@
 </menu>
 
 <h2>components/ember-youtube</h2>
+<div>{{myPlayer.currentTimeFormatted}} / {{myPlayer.durationFormatted}}</div>
 {{ember-youtube
 	ytid=youTubeId
 
@@ -27,6 +28,10 @@
 	delegate-as="myPlayer"
 
 	showDebug=true
+	autoplay=true
+
+	currentTimeFormat="mm:ss"
+	durationFormat="mm:ss"
 
 	playing="ytPlaying"
 	paused="ytPaused"


### PR DESCRIPTION
This PR enables the users to decide which format they want to use for the **currentTimeFormatted** and **durationFormatted** properties based on any of the [momentJS](http://www.momentjs.com) [formats](http://momentjs.com/docs/#/parsing/string-format/).

Example:

```html
{{ember-youtube ytid=youTubeId currentTimeFormat="mm:ss" durationFormat="hh:mm:ss"}}
```

BTW, Thanks for lib! it solves all my requirements and have a nice Api, good job :rocket:  