### PR TITLE
Improved video-player initialization and teardown.

### DIFF
--- a/addon/components/ember-youtube.js
+++ b/addon/components/ember-youtube.js
@@ -63,20 +63,32 @@ export default Ember.Component.extend({
 		this.playerVars.autoplay = this.get('autoplay') ? 1 : 0;
 	})),
 
-	// Load the iframe player API asynchronously from YouTube
-	loadApi: on('init', function() {
-		let tag = document.createElement('script');
-		let firstTag = document.getElementsByTagName('script')[0];
-
-		tag.src = "https://www.youtube.com/iframe_api";
-		firstTag.parentNode.insertBefore(tag, firstTag);
-
-		// YouTube callback when API is ready
-		window.onYouTubePlayerAPIReady = function() {
-			if (this.get('showDebug')) { debug('yt player api ready'); }
+	// Did insert element hook
+	didInsertElement: function(){
+		// check if YouTube API is already available
+		if(typeof YT === "undefined"){
+			var _this = this;
+			// load the api script and call createPlayer when API is ready
+			Ember.$.getScript("https://www.youtube.com/iframe_api").then(function(){
+				window.onYouTubePlayerAPIReady = _this.createPlayer.bind(_this);
+			});
+		} else {
 			this.createPlayer();
-		}.bind(this);
-	}),
+		}
+	},
+
+	// clean up when element will be destroyed.
+	willDestroyElement: function(){
+		// clear the timer
+		this.stopTimer();
+
+		// destroy video player
+		var player = this.get('player');
+		if(player){
+			player.destroy();
+			this.set('player', null);
+		}
+	},
 
 	isPlaying: computed('playerState', function() {
 		let player = this.get('player');
@@ -86,7 +98,6 @@ export default Ember.Component.extend({
 	}),
 
 	createPlayer: function() {
-		let _this = this;
 		let playerVars = this.get('playerVars');
 		let $iframe = this.$('#EmberYoutube-player');
 
@@ -95,9 +106,9 @@ export default Ember.Component.extend({
 			height: 270,
 			playerVars: playerVars,
 			events: {
-				'onReady': _this.onPlayerReady.bind(_this),
-				'onStateChange': _this.onPlayerStateChange.bind(_this),
-				'onError': _this.onPlayerError.bind(_this)
+				'onReady': this.onPlayerReady.bind(this),
+				'onStateChange': this.onPlayerStateChange.bind(this),
+				'onError': this.onPlayerError.bind(this)
 			}
 		});
 
@@ -187,6 +198,11 @@ export default Ember.Component.extend({
 		// }
 	},
 
+	timerChanged: function(){
+		// stop the previous timer
+		this.stopTimer();
+	}.observesBefore('timer'),
+
 	startTimer: function() {
 		let player = this.get('player');
 
@@ -216,7 +232,7 @@ export default Ember.Component.extend({
 		let time = this.get('currentTime');
 		let format = this.get('currentTimeFormat');
 		if (!time || !format) { return; }
-		let duration = moment.duration(time, 'seconds');		
+		let duration = moment.duration(time, 'seconds');
 		return duration.format(format);
 	}),
 
@@ -231,7 +247,7 @@ export default Ember.Component.extend({
 		let time = this.get('duration');
 		let format = this.get('durationFormat');
 		if (!time || !format) { return; }
-		let duration = moment.duration(time, 'seconds');		
+		let duration = moment.duration(time, 'seconds');
 		return duration.format(format);
 	}),
 

--- a/app/blueprints/ember-youtube.js
+++ b/app/blueprints/ember-youtube.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-youtube/blueprints/ember-youtube';

--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "predef": [
+    "console"
+  ],
+  "strict": false
+}

--- a/blueprints/ember-youtube/index.js
+++ b/blueprints/ember-youtube/index.js
@@ -1,0 +1,11 @@
+module.exports = {
+  description: 'install bower dependencies',
+  normalizeEntityName: function() {},
+  afterInstall: function(options) {
+    var _this = this;
+    return _this.addBowerPackageToProject('moment').then(function() {
+      return _this.addBowerPackageToProject('moment-duration-format');
+    });
+
+  }
+};


### PR DESCRIPTION
Fixes issue #12 

Now properly creates a video-player every time the component is attached to the view and also shuts down/destroys a playing video when the component gets removed.

Changes:
 - Loading script via jQuery getScript instead of building script tags manually.
 - Added `didInsertElement` where player API will be initialized.
 - Added  `willDestroyElement` to properly shut down/destroy videoplayer.
 - Added blueprint to include bower dependencies upon installation.