### PR TITLE
Improved video-player initialization and teardown.

### DIFF
--- a/app/blueprints/ember-youtube.js
+++ b/app/blueprints/ember-youtube.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-youtube/blueprints/ember-youtube';

--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "predef": [
+    "console"
+  ],
+  "strict": false
+}

--- a/blueprints/ember-youtube/index.js
+++ b/blueprints/ember-youtube/index.js
@@ -1,0 +1,11 @@
+module.exports = {
+  description: 'install bower dependencies',
+  normalizeEntityName: function() {},
+  afterInstall: function(options) {
+    var _this = this;
+    return _this.addBowerPackageToProject('moment').then(function() {
+      return _this.addBowerPackageToProject('moment-duration-format');
+    });
+
+  }
+};


### PR DESCRIPTION
Fixes issue #12

New PR without dependency on `observesBefore`. Instead timer is being cleared every time when setting a new timer.

Squashed commits:
[055d311] Loading script via jQuery getScript instead of building script tags manually.
Added `didInsertElement` where player API will be initialized.
Added  `willDestroyElement` to properly shut down/destroy videoplayer.
Added blueprint to include bower dependencies upon installation.