### PR TITLE
Fix api script loading race condition

### DIFF
--- a/addon/components/ember-youtube.js
+++ b/addon/components/ember-youtube.js
@@ -65,18 +65,17 @@ export default Ember.Component.extend({
 
 	// Did insert element hook
 	loadAndCreatePlayer: on('didInsertElement', function() {
-
-		// check if YouTube API is already available
-		if (typeof YT === "undefined") {
-			var self = this;
-
-			// load the api script and call createPlayer when API is ready
-			Ember.$.getScript("https://www.youtube.com/iframe_api").then(() => {
-				window.onYouTubePlayerAPIReady = self.createPlayer.bind(this);
+    if (!window._youtubePlayerAPIReadyPromise) {
+      var deferred = Ember.RSVP.defer();
+      Ember.$.getScript("https://www.youtube.com/iframe_api").then(() => {
+				window.onYouTubePlayerAPIReady = deferred.resolve;
 			});
-		} else {
+      window._youtubePlayerAPIReadyPromise = deferred.promise;
+    }
+
+    window._youtubePlayerAPIReadyPromise.then(() => {
 			this.createPlayer();
-		}
+    });
 	}),
 
 	isMuted: computed({


### PR DESCRIPTION
This bug surfaced when loading multiple youtube videos in the same page.

Because the `didInsertElement` hook only checks for the presence of the YT global before requesting the  Youtube iframe api script, there will be a race condition where YT will be undefined, and `$.getScript` will be called multiple times and making multiple requests for the same file if `ember-youtube` is on the page more than once. 

`window.onYouTubePlayerAPIReady` will also get redefined each time in the promise success handler, causing the call to `self.createPlayer` to never happen to any of players after the first.

This PR ensures that the Youtube script is only loaded once, and keeps track of the state via a promise on `window`. Once the script finally loads and `window.onYouTubePlayerAPIReady` is called by Youtube, the promise is resolved and all players correctly get called with `createPlayer`.