### PR TITLE
replace moment.js in bower_components by ember-moment

### DIFF
--- a/addon/components/ember-youtube.js
+++ b/addon/components/ember-youtube.js
@@ -1,8 +1,8 @@
 /* global YT, window */
 import Ember from 'ember';
+import moment from 'moment';
 
 const {computed, debug, observer, on, run} = Ember;
-const moment = window.moment;
 
 export default Ember.Component.extend({
 	classNames: ['EmberYoutube'],

--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
 
-    app.import(app.bowerDirectory + '/moment/moment.js');
     app.import(app.bowerDirectory + '/moment-duration-format/lib/moment-duration-format.js');
   }
 };

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
+    "ember-moment": "^6.0.0",
     "ember-try": "~0.0.8"
   },
   "keywords": [


### PR DESCRIPTION
Hi, again :) now I propose to replace moment.js that install in `bower_components` by ember-moment addon. 

The main reason is getting work `ember-moment` in the main project dependent on `ember-moment` and `ember-youtube` at the same time. Now this collaboration impossible because `moment.js` required by `ember-youtube` redefine `moment.js` required by `ember-moment` for the main app. And all i18n settings has broken by the reason of redefining `moment` variable. And when `ember-moment` trying to get `moment` it gets `ember-youtube`'s `moment` because it's global variable.

The second reason is that `ember-moment` gives ES2015-shim for global `moment` var to you. Since you can import `moment` to your project anywhere like I did it in the PR's commit.

`moment-duration-format` works fine anyway.