### PR TITLE
add external playerCreated, and playerStateChange actions

### DIFF
--- a/addon/components/ember-youtube.js
+++ b/addon/components/ember-youtube.js
@@ -76,6 +76,7 @@ export default Ember.Component.extend({
 						player,
 						playerState: 'ready'
 					});
+					this.sendAction('playerCreated', player);
 					this.set('loadAndCreatePlayerIsRunning', false);
 					resolve();
 				})
@@ -157,6 +158,7 @@ export default Ember.Component.extend({
 		}
 		// send actions outside
 		this.sendAction(state);
+		this.sendAction('playerStateChanged', event);
 		// send actions inside
 		this.send(state);
 	},


### PR DESCRIPTION
I added these for my own personal uses because found the current setup a little limiting, and I feel others might find these useful as well. The player created action passes the player which can then be directly controlled. I've also added the playerStateChange event with the actual event if any of the details need to be obtained.