### PR TITLE
include event in granular state changes

### DIFF
--- a/addon/components/ember-youtube.js
+++ b/addon/components/ember-youtube.js
@@ -158,7 +158,7 @@ export default Ember.Component.extend({
 			debug(state);
 		}
 		// send actions outside
-		this.sendAction(state);
+		this.sendAction(state, event);
 		this.sendAction('playerStateChanged', event);
 		// send actions inside
 		this.send(state);


### PR DESCRIPTION
include the `event` object in the more granular `playing`, `paused`, etc calls so users can use the player API on those specific events.