### PR TITLE
Ensure component `init()` does not overwrite `this.playerVars`

### DIFF
--- a/addon/components/ember-youtube.js
+++ b/addon/components/ember-youtube.js
@@ -35,7 +35,7 @@ export default Component.extend({
 			// YouTube's embedded player can take a number of optional parameters.
 			// https://developers.google.com/youtube/player_parameters#Parameters
 			// https://developers.google.com/youtube/youtube_player_demo
-			playerVars: {},
+			playerVars: Object.assign({}, this.playerVars),
 			// from YT.PlayerState
 			stateNames: {
 				'-1': 'ready',		// READY


### PR DESCRIPTION
Was having trouble with `autoplay: 1` not running; this fixes it.