### PR TITLE
Remove deprecated sendAction()

### DIFF
--- a/addon/components/ember-youtube.js
+++ b/addon/components/ember-youtube.js
@@ -28,33 +28,33 @@ export default Component.extend({
 	playerState: 'loading',
 
 	/* Hooks */
-	playerCreated(player) {
+	playerCreated() {
 		/* Callback to be passed. */
 	},
-	playerStateChanged(event) {
+	playerStateChanged() {
 		/* Callback to be passed. */
 	},
-	error(errorCode) {
+	error() {
 		/* Callback to be passed. */
 	},
 
 	/* State hooks */
-	ready(event) {
+	ready() {
 		/* Callback to be passed. */
 	},
-	ended(event) {
+	ended() {
 		/* Callback to be passed. */
 	},
-	playing(event) {
+	playing() {
 		/* Callback to be passed. */
 	},
-	paused(event) {
+	paused() {
 		/* Callback to be passed. */
 	},
-	buffering(event) {
+	buffering() {
 		/* Callback to be passed. */
 	},
-	queued(event) {
+	queued() {
 		/* Callback to be passed. */
 	},
 

--- a/addon/components/ember-youtube.js
+++ b/addon/components/ember-youtube.js
@@ -27,6 +27,37 @@ export default Component.extend({
 	player: null,
 	playerState: 'loading',
 
+	/* Hooks */
+	playerCreated(player) {
+		/* Callback to be passed. */
+	},
+	playerStateChanged(event) {
+		/* Callback to be passed. */
+	},
+	error(errorCode) {
+		/* Callback to be passed. */
+	},
+
+	/* State hooks */
+	ready(event) {
+		/* Callback to be passed. */
+	},
+	ended(event) {
+		/* Callback to be passed. */
+	},
+	playing(event) {
+		/* Callback to be passed. */
+	},
+	paused(event) {
+		/* Callback to be passed. */
+	},
+	buffering(event) {
+		/* Callback to be passed. */
+	},
+	queued(event) {
+		/* Callback to be passed. */
+	},
+
 	init() {
 		this._super();
 
@@ -107,7 +138,7 @@ export default Component.extend({
 				playerState: 'ready'
 			});
 
-			this.sendAction('playerCreated', player);
+			this.playerCreated(player);
 
 			this.loadVideo();
 		} catch(err) {
@@ -181,8 +212,8 @@ export default Component.extend({
 			debug(state);
 		}
 		// send actions outside
-		this.sendAction(state, event);
-		this.sendAction('playerStateChanged', event);
+		this[state](event);
+		this.playerStateChanged(event);
 		// send actions inside
 		this.send(state);
 	},
@@ -192,7 +223,7 @@ export default Component.extend({
 		let errorCode = event.data;
 		this.set('playerState', 'error');
 		// Send the event to the controller
-		this.sendAction('error', errorCode);
+		this.error(errorCode);
 		if (this.get('showDebug')) {
 			debug('error' + errorCode);
 		}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -32,9 +32,10 @@
 		delegate=this
 		delegate-as="emberYoutube"
 
-		playing="ytPlaying"
-		paused="ytPaused"
-		ended="ytEnded"}}
+		playing=(action "ytPlaying")
+		paused=(action "ytPaused")
+		ended=(action "ytEnded")
+	}}
 </section>
 
 <p>Multiple players on the same route are supported as well.</p>


### PR DESCRIPTION
sendAction() is under deprication warning. There are now new functions for all possible substitutions of sendAction.